### PR TITLE
Update the spree-client version

### DIFF
--- a/lib/blue_apron/spree_client/version.rb
+++ b/lib/blue_apron/spree_client/version.rb
@@ -1,5 +1,5 @@
 module BlueApron
   class SpreeClient
-    VERSION = '1.0.8.pre'
+    VERSION = '1.1.0.pre'
   end
 end


### PR DESCRIPTION
I mistakenly forgot to update the spree-client version in my previous PR. This PR bumps the version number so we can update ba.com easily.

[no-jira] Version bump