### PR TITLE
Dependency update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spree_client (1.0.8.pre)
+    spree_client (1.1.1.pre)
       faraday
       hashie
       json
@@ -10,18 +10,18 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    crass (0.2.1)
+    crass (1.0.4)
     diff-lcs (1.2.5)
-    faraday (0.9.0)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    hashie (3.3.1)
-    json (1.8.1)
-    mini_portile (0.6.0)
+    hashie (3.6.0)
+    json (2.1.0)
+    mini_portile2 (2.3.0)
     multipart-post (2.0.0)
-    nokogiri (1.6.3.1)
-      mini_portile (= 0.6.0)
-    nokogumbo (1.1.12)
-      nokogiri
+    nokogiri (1.8.5)
+      mini_portile2 (~> 2.3.0)
+    nokogumbo (2.0.1)
+      nokogiri (~> 1.8, >= 1.8.4)
     rake (10.3.2)
     rspec (3.0.0)
       rspec-core (~> 3.0.0)
@@ -35,10 +35,10 @@ GEM
     rspec-mocks (3.0.2)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.2)
-    sanitize (3.0.2)
-      crass (~> 0.2.0)
-      nokogiri (>= 1.4.4)
-      nokogumbo (= 1.1.12)
+    sanitize (5.0.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.8.0)
+      nokogumbo (~> 2.0)
 
 PLATFORMS
   ruby
@@ -47,3 +47,6 @@ DEPENDENCIES
   rake
   rspec
   spree_client!
+
+BUNDLED WITH
+   1.16.1

--- a/lib/blue_apron/spree_client/version.rb
+++ b/lib/blue_apron/spree_client/version.rb
@@ -1,5 +1,5 @@
 module BlueApron
   class SpreeClient
-    VERSION = '1.1.0.pre'
+    VERSION = '1.1.1.pre'
   end
 end


### PR DESCRIPTION
This PR simply updates the dependencies of the Spree Client gem to latest. All I did was run `bundle install` - this is the output of that.

Looking through the changelings, this all looks innocuous for us:
crass 0.2.1 -> 1.0.4
* Mostly bug fixes, and compliance with CSS spec
* Same as ba.com version

faraday 0.9.0 -> 0.15.4:
* No breaking changes, adds a few bug fixes/features that we aren’t using.

hashie 3.3.1 -> 3.6.0:
* No breaking changes, bug fixes.

json 1.8.1 -> 2.1.0:
* Complies with RFC 7159, no breaking changes.
* This is the version we use in ba.com already.

mini_portile 0.6.0 -> mini_portile2 2.3.0:
* This came from Nokogiri, and wasn’t used directly.
* Already used in ba.com

nokogiri 1.6.3.1 -> 1.8.5:
* No breaking changes
* Same as ba.com version

nokogumbo 1.1.12 -> 2.0.1:
* No breaking changes
* Same as ba.com version

sanitize 3.0.2 -> 5.0.0:
* No breaking changes
* Same as ba.com version

[no-jira] Dependency update