### PR TITLE
Add support for passing cart_type to Marketplace

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spree_client (1.0.8.pre)
+    spree_client (1.2.0.pre)
       faraday
       hashie
       json
@@ -10,18 +10,18 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    crass (0.2.1)
+    crass (1.0.4)
     diff-lcs (1.2.5)
-    faraday (0.9.0)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    hashie (3.3.1)
-    json (1.8.1)
-    mini_portile (0.6.0)
+    hashie (3.6.0)
+    json (2.1.0)
+    mini_portile2 (2.3.0)
     multipart-post (2.0.0)
-    nokogiri (1.6.3.1)
-      mini_portile (= 0.6.0)
-    nokogumbo (1.1.12)
-      nokogiri
+    nokogiri (1.8.5)
+      mini_portile2 (~> 2.3.0)
+    nokogumbo (2.0.1)
+      nokogiri (~> 1.8, >= 1.8.4)
     rake (10.3.2)
     rspec (3.0.0)
       rspec-core (~> 3.0.0)
@@ -35,10 +35,10 @@ GEM
     rspec-mocks (3.0.2)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.2)
-    sanitize (3.0.2)
-      crass (~> 0.2.0)
-      nokogiri (>= 1.4.4)
-      nokogumbo (= 1.1.12)
+    sanitize (5.0.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.8.0)
+      nokogumbo (~> 2.0)
 
 PLATFORMS
   ruby
@@ -47,3 +47,6 @@ DEPENDENCIES
   rake
   rspec
   spree_client!
+
+BUNDLED WITH
+   1.16.1

--- a/lib/blue_apron/spree_client.rb
+++ b/lib/blue_apron/spree_client.rb
@@ -107,8 +107,8 @@ module BlueApron
       get "/api/shipments/#{id}", options
     end
 
-    def get_current_order_for(user_id)
-      get "/api/orders/current_for/#{user_id}"
+    def get_current_order_for(user_id, options = {})
+      get "/api/orders/current_for/#{user_id}", params: options
     end
 
     def get_orders(options = {})

--- a/lib/blue_apron/spree_client.rb
+++ b/lib/blue_apron/spree_client.rb
@@ -108,7 +108,7 @@ module BlueApron
     end
 
     def get_current_order_for(user_id, options = {})
-      get "/api/orders/current_for/#{user_id}", params: options
+      get "/api/orders/current_for/#{user_id}", options
     end
 
     def get_orders(options = {})

--- a/lib/blue_apron/spree_client/version.rb
+++ b/lib/blue_apron/spree_client/version.rb
@@ -1,5 +1,5 @@
 module BlueApron
   class SpreeClient
-    VERSION = '1.1.0.pre'
+    VERSION = '1.2.0.pre'
   end
 end

--- a/spec/blue_apron/spree_client_spec.rb
+++ b/spec/blue_apron/spree_client_spec.rb
@@ -241,8 +241,9 @@ describe BlueApron::SpreeClient do
 
   describe '#get_current_for_order' do
     let(:user_id) { 1234 }
+    let(:params) { {} }
 
-    subject { spree_client.get_current_order_for(user_id) }
+    subject { spree_client.get_current_order_for(user_id, params) }
 
     context 'when response is 200' do
       before(:each) do
@@ -252,6 +253,21 @@ describe BlueApron::SpreeClient do
         end
         expect(spree_client).to receive(:connection).and_return(connection)
       end
+
+      it_behaves_like "a Hashie::Mash"
+    end
+
+    context 'when parameters are provided' do
+      before(:each) do
+        stubs.get("/api/orders/current_for/#{user_id}") do |env|
+          validate_json_request(env)
+          expect(env[:params]).to eq(params)
+          [200, {'Content-Type' => 'application/json'}, read_fixture_file('get_api_order.json')]
+        end
+        expect(spree_client).to receive(:connection).and_return(connection)
+      end
+
+      let(:params) { { 'cart_type' => 'on_demand', 'payment' => 'your_soul' } }
 
       it_behaves_like "a Hashie::Mash"
     end

--- a/spec/blue_apron/spree_client_spec.rb
+++ b/spec/blue_apron/spree_client_spec.rb
@@ -241,9 +241,9 @@ describe BlueApron::SpreeClient do
 
   describe '#get_current_for_order' do
     let(:user_id) { 1234 }
-    let(:params) { {} }
+    let(:options) { {} }
 
-    subject { spree_client.get_current_order_for(user_id, params) }
+    subject { spree_client.get_current_order_for(user_id, options) }
 
     context 'when response is 200' do
       before(:each) do
@@ -268,6 +268,7 @@ describe BlueApron::SpreeClient do
       end
 
       let(:params) { { 'cart_type' => 'on_demand', 'payment' => 'your_soul' } }
+      let(:options) { { params: params } }
 
       it_behaves_like "a Hashie::Mash"
     end
@@ -616,7 +617,7 @@ describe '#patch_order' do
   end
 
   describe '#sanitize_product' do
-    let(:html_text) { '<h1>Hello World <script>alert("HACKED")</script></h1>' }
+    let(:html_text) { '<h1>Hello World<script>alert("HACKED")</script></h1>' }
     let(:product) { Hashie::Mash.new(cms_text: html_text, description: html_text, product_properties: product_properties) }
     let(:product_properties) { [Hashie::Mash.new(value: html_text)] }
 
@@ -624,7 +625,7 @@ describe '#patch_order' do
 
     it 'should remove <script> tags' do
       subject
-      cleaned = '<h1>Hello World alert("HACKED")</h1>'
+      cleaned = '<h1>Hello World</h1>'
       expect(product.cms_text).to eq(cleaned)
       expect(product.description).to eq(cleaned)
       expect(product.product_properties.first.value).to eq(cleaned)
@@ -633,10 +634,10 @@ describe '#patch_order' do
 
   describe '#sanitize_html' do
     subject { spree_client.send(:sanitize_html, html) }
-    let(:html) { '<h1>Hello World <script>alert("HACKED")</script></h1>' }
+    let(:html) { '<h1>Hello World<script>alert("HACKED")</script></h1>' }
 
     it 'should remove <script> tags' do
-      expect(subject).to eq('<h1>Hello World alert("HACKED")</h1>')
+      expect(subject).to eq('<h1>Hello World</h1>')
     end
   end
 


### PR DESCRIPTION
This PR adds support for requesting orders with a specific cart_type when asking for the current order. This will allow us to filter out on-demand orders historically, and not mixing our carts.

Note: this depends on https://github.com/blueapron/spree-client-ruby/pull/11, which should go in first. (The gem file changes here are the same as that PR, modulo the gem itself)

[OD-41](https://jira.blueapron.com/browse/OD-41)