### PR TITLE
Set logging middleware before adapter is set

### DIFF
--- a/lib/blue_apron/spree_client.rb
+++ b/lib/blue_apron/spree_client.rb
@@ -293,11 +293,9 @@ module BlueApron
 
       def connection
         Faraday.new(:url => @url) do |faraday|
-          faraday.request  :url_encoded
-          faraday.adapter  Faraday.default_adapter
-          if @logger
-            faraday.use      Faraday::Response::Logger, @logger
-          end
+          faraday.request :url_encoded
+          faraday.use(Faraday::Response::Logger, @logger) if @logger
+          faraday.adapter Faraday.default_adapter
         end
       end
 


### PR DESCRIPTION
Fixes `WARNING: Unexpected middleware set after the adapter. This won't be supported from Faraday 1.0`