### PR TITLE
Allow setting target in links from Marketplace

### DIFF
--- a/lib/blue_apron/spree_client.rb
+++ b/lib/blue_apron/spree_client.rb
@@ -316,7 +316,13 @@ module BlueApron
       end
 
       def sanitize_html(s)
-        Sanitize.fragment(s, Sanitize::Config::RELAXED)
+        Sanitize.fragment(s, sanitize_config)
       end
+
+      def sanitize_config
+        @sanitize_config ||= begin
+          attrs = { 'a' => Sanitize::Config::RELAXED[:attributes]['a'] + ['target'] }
+          Sanitize::Config.merge(Sanitize::Config::RELAXED, attributes: attrs)
+        end
   end
 end

--- a/lib/blue_apron/spree_client/version.rb
+++ b/lib/blue_apron/spree_client/version.rb
@@ -1,5 +1,5 @@
 module BlueApron
   class SpreeClient
-    VERSION = '1.4.0'
+    VERSION = '1.5.0'
   end
 end


### PR DESCRIPTION
This PR allows us to specify a `target` params in our marketplace links. Previously, this was being sanitized out - preventing us from authoring products which link to new tabs.

[PLAT-1426](https://jira.blueapron.com/browse/PLAT-1426)