### PR TITLE
Sigh - bad syntax

### DIFF
--- a/lib/blue_apron/spree_client.rb
+++ b/lib/blue_apron/spree_client.rb
@@ -324,5 +324,6 @@ module BlueApron
           attrs = { 'a' => Sanitize::Config::RELAXED[:attributes]['a'] + ['target'] }
           Sanitize::Config.merge(Sanitize::Config::RELAXED, attributes: attrs)
         end
+      end
   end
 end

--- a/lib/blue_apron/spree_client/version.rb
+++ b/lib/blue_apron/spree_client/version.rb
@@ -1,5 +1,5 @@
 module BlueApron
   class SpreeClient
-    VERSION = '1.5.0'
+    VERSION = '1.5.1'
   end
 end


### PR DESCRIPTION
This PR fixes up a missing `end` in the latest change. Whoops. I tested this version by pointing my local ba.com env at the new gem, and this version fixes the bug. This is what I get for trying to go too quickly! :-/

[PLAT-1426](https://jira.blueapron.com/browse/PLAT-1426)